### PR TITLE
feat: include sha in report

### DIFF
--- a/action/lib/lint.js
+++ b/action/lib/lint.js
@@ -23,6 +23,7 @@ module.exports = async function ({ commits, config = 'conventional' }) {
     core.info(`${sha.slice(-7)}: ${message}`)
 
     const result = await lint.default(message, rules, rawOpts)
+    result.sha = sha
 
     if (result.errors.length > 0) {
       fail = true


### PR DESCRIPTION
Include the SHA of each commit in the report output.

I want to be able to marry this action with mshick/add-pr-comment.

```yaml
  commitlint:
    name: commitlint
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v3

      - name: Run commitlint
        id: commitlint
        uses: twang817/action-commit-lint@v1  # this would be ahmadnassri/action-commit-lint@v2 after this PR

      - name: Report to data file
        if: failure()
        run: |
          echo '{"report": ${{ steps.commitlint.outputs.report }}}' > .github/commitlint-data.json
          cat .github/commitlint-data.json

      - name: Render comment template
        uses: cuchi/jinja2-action@v1.2.0
        if: failure()
        with:
          template: .github/commitlint-comment.md.j2
          data_file: .github/commitlint-data.json
          output_file: .github/commitlint-comment.md
          strict: true

      - name: Log comment file
        if: failure()
        run: |
          echo '{"report": ${{ steps.commitlint.outputs.report }}}' > .github/commitlint-data.json
          cat .github/commitlint-comment.md

      - name: Create template for success
        if: success()
        run: |
          echo "All commit messages :white_check_mark:" > .github/commitlint-comment.md
          cat .github/commitlint-comment.md

      - name: Comment on PR
        uses: mshick/add-pr-comment@v2
        if: success() || failure()
        with:
          message-id: commitlint
          message-path: .github/commitlint-comment.md
```

The commit template is handled using cuchi/jinja2-action, but any template engine should work.  The comment file:

```markdown
Commits should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax:

**Commits**:
{% for commit in report %}
<details>
  <summary>⧗ {{ commit["sha"][0:7] }} {{ commit["input"] }}</summary>

{% for error in commit["errors"] -%}
{% if loop.index == 1 -%}> {% endif -%}
✖ {{ error["message"] }}{{"  "}}
{% endfor -%}
{% for warning in commit["warnings"] -%}
{% if loop.index == 1 -%}> {% endif -%}
⚠  {{ warning["message"] }}{{"  "}}
{% endfor -%}
</details>
{% endfor %}
```

And it looks something like this:

![SCR-20230331-jytx](https://user-images.githubusercontent.com/766820/229170458-fe5a2a40-1f9e-4f8e-805b-dd3c6b30f5b8.png)

And after all commits are reworded:

![image](https://user-images.githubusercontent.com/766820/229170612-03e7b851-fef5-4f64-8b8c-6bc5b01a7a96.png)
