### PR TITLE
fix: create the node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN node install.js
 
 FROM base AS app
 
+RUN useradd -ms /bin/bash node
+
 LABEL com.github.actions.name="Conventional Commit Lint" \
   com.github.actions.description="commitlint your PRs with Conventional style" \
   com.github.actions.icon="search" \


### PR DESCRIPTION
Create the node user before trying to use it.

Currently, the action fails with:
```
docker: Error response from daemon: unable to find user node: no matching entries in passwd file.
```