### PR TITLE
fix: fix adding the node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN node install.js
 
 FROM base AS app
 
-RUN useradd -ms /bin/bash node
+RUN addgroup -g 1000 node \
+  && adduser -u 1000 -G node -s /bin/sh -D node
 
 LABEL com.github.actions.name="Conventional Commit Lint" \
   com.github.actions.description="commitlint your PRs with Conventional style" \


### PR DESCRIPTION
User adduser instead of useradd since the former isn't installed in the base alpine image.

Add both a node user and group with 1000 id following the same procedure as the official nodejs image.

https://github.com/nodejs/docker-node/blob/main/Dockerfile-alpine.template#L5