### PR TITLE
fix: remove USER instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,6 @@ RUN node install.js
 
 FROM base AS app
 
-RUN addgroup -g 1000 node \
-  && adduser -u 1000 -G node -s /bin/sh -D node
-
 LABEL com.github.actions.name="Conventional Commit Lint" \
   com.github.actions.description="commitlint your PRs with Conventional style" \
   com.github.actions.icon="search" \
@@ -45,8 +42,6 @@ COPY --from=build /action/node_modules ./node_modules
 
 # copy files
 COPY src ./
-
-USER node
 
 HEALTHCHECK NONE
 


### PR DESCRIPTION
Remove the USER instruction in the Dockerfile to make it run as the default root user, which is required by github.

> Docker actions must be run by the default Docker user (root).
> Do not use the USER instruction in your Dockerfile, because you
> won't be able to access the GITHUB_WORKSPACE directory.
> For more information, see "Variables" and USER reference in the Docker documentation.

https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user

Without this, it fails due to permission errors:
```
Error: EACCES: permission denied, open '/github/file_commands/set_output_...'
```